### PR TITLE
feat(make_image): add 9_image_edit_bravo to model_series enum and docs

### DIFF
--- a/.changeset/bravo-model.md
+++ b/.changeset/bravo-model.md
@@ -1,0 +1,8 @@
+---
+"@talesofai/neta-skills": minor
+---
+
+feat(make_image): add 9_image_edit_bravo to model_series enum and docs
+
+- Extend the `make_image` CLI `model_series` TypeBox schema to accept `9_image_edit_bravo`.
+- Update English and Chinese skill reference docs with a minimal description of the new model option.

--- a/.changeset/bravo-model.md
+++ b/.changeset/bravo-model.md
@@ -1,8 +1,0 @@
----
-"@talesofai/neta-skills": minor
----
-
-feat(make_image): add 9_image_edit_bravo to model_series enum and docs
-
-- Extend the `make_image` CLI `model_series` TypeBox schema to accept `9_image_edit_bravo`.
-- Update English and Chinese skill reference docs with a minimal description of the new model option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neta/skills-neta
 
+## 0.18.0
+
+### Minor Changes
+
+- 1e7536f: feat(make_image): add 9_image_edit_bravo to model_series enum and docs
+
+  - Extend the `make_image` CLI `model_series` TypeBox schema to accept `9_image_edit_bravo`.
+  - Update English and Chinese skill reference docs with a minimal description of the new model option.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talesofai/neta-skills",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Neta API pi coding agent skills for interacting with Neta API to generate images, videos, songs, and manage characters/elements.",
   "type": "module",
   "repository": {

--- a/skills/neta-creative/references/image-generation.md
+++ b/skills/neta-creative/references/image-generation.md
@@ -54,6 +54,8 @@ npx -y @talesofai/neta-skills@latest make_image \
   --model_series "8_image_edit"
 ```
 
+- **9_image_edit_bravo**: Updated experimental model. Only use when explicitly requested by the user.
+
 ## Aspect Ratio Selection
 
 | Ratio | Resolution | Use Cases |

--- a/skills/zh_cn/neta-creative/references/image-generation.md
+++ b/skills/zh_cn/neta-creative/references/image-generation.md
@@ -54,6 +54,8 @@ npx -y @talesofai/neta-skills@latest make_image \
   --model_series "8_image_edit"
 ```
 
+- 9_image_edit_bravo: 更新的试验性模型，仅在用户明确要求时使用。
+
 ## 宽高比选择
 
 | 比例 | 分辨率 | 适用场景 |

--- a/src/commands/creative/make_image.cmd.ts
+++ b/src/commands/creative/make_image.cmd.ts
@@ -50,7 +50,11 @@ const makeImageV1Parameters = Type.Object({
     }),
   ),
   model_series: Type.Union(
-    [Type.Literal("8_image_edit"), Type.Literal("3_noobxl")],
+    [
+      Type.Literal("8_image_edit"),
+      Type.Literal("3_noobxl"),
+      Type.Literal("9_image_edit_bravo"),
+    ],
     {
       default: "8_image_edit",
       description: meta.parameters.model_series,


### PR DESCRIPTION
## Summary
- Extend the `make_image` CLI `model_series` TypeBox schema to accept `9_image_edit_bravo`.
- Update English and Chinese skill reference docs with a minimal description of the new model option.

The underlying API already supported this model; the CLI enum was the only blocker.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `make_image --help` lists `9_image_edit_bravo` as a valid choice

🤖 Generated with [Claude Code](https://claude.com/code)